### PR TITLE
Move source and target gap summaries out of top-level and into mapping

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -47,6 +47,12 @@
             <assembly ref="map" min-occurs="1" max-occurs="unbounded">
                 <group-as name="maps" in-json="ARRAY" />
             </assembly>
+            <assembly ref="gap-summary">
+                <use-name>source-gap-summary</use-name>
+            </assembly>
+            <assembly ref="gap-summary">
+                <use-name>target-gap-summary</use-name>
+            </assembly>
         </model>
     </define-assembly>
 

--- a/src/metaschema/oscal_mapping_metaschema.xml
+++ b/src/metaschema/oscal_mapping_metaschema.xml
@@ -36,12 +36,6 @@
                   <assembly ref="mapping" min-occurs="1" max-occurs="unbounded">
                         <group-as name="mappings" />
                   </assembly>
-                  <assembly ref="gap-summary">
-                        <use-name>source-gap-summary</use-name>
-                  </assembly>
-                  <assembly ref="gap-summary">
-                        <use-name>target-gap-summary</use-name>
-                  </assembly>
                   <assembly ref="back-matter">
                         <remarks>
                               <p>Back matter including references and resources.</p>


### PR DESCRIPTION
The two gap summary assemblies "source-gap-summary" and "target-gap-summary" make unqualified ID references to controls that are undefined at the document level.

Review and discussion with NIST has indicated that these assembles are intended to be inside the "mapping" assembly, where the ID references can be resolved against "source-resource" and "target-resource".

This Pull Request remediates the issue by moving the gap summary assemblies.