### PR TITLE
Allow for non-OSCAL resources in "source-resource" and "target-resource"

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -203,16 +203,30 @@
     <define-assembly name="mapping-resource-reference">
         <formal-name>Mapped Resource Reference</formal-name>
         <description>A reference to a resource that is either the source or the target of a mapping.</description>
+        <define-flag name="ns" as-type="uri" default="http://csrc.nist.gov/ns/oscal" required="no">
+            <formal-name>Resource Type Namespace</formal-name>
+            <description>An optional namespace qualifying the resource's <code>type</code>. </description>
+            <remarks>
+                    <p>This value must be an <a href="https://pages.nist.gov/OSCAL/concepts/uri-use/#absolute-uri">absolute URI</a> that serves as a <a href="https://pages.nist.gov/OSCAL/concepts/uri-use/#use-as-a-naming-system-identifier">naming system identifier</a>.</p>
+                    <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> and the type should be a type defined by the associated OSCAL model.</p>
+            </remarks>
+        </define-flag>
         <define-flag name="type" as-type="token" required="yes">
             <formal-name>Resource Type</formal-name>
             <description>The semantic type of the resource.</description>
             <constraint>
-                <allowed-values>
+                <allowed-values allow-others="yes">
                     <enum value="catalog">The mapped resource is a control catalog.</enum>
                     <enum value="profile">The mapped resource is a control profile. A resolved
                         profile is also accepted.</enum>
                 </allowed-values>
             </constraint>
+            <remarks>
+                <p>The <code>type</code> value must be interpreted in the context of the
+                    associated <code>ns</code> value.</p>
+                    <p>When a <code>ns</code> is not provided, its value should be assumed to be <code>http://csrc.nist.gov/ns/oscal</code> 
+                    and this type should be set to one of the OSCAL defined values.</p>
+            </remarks>
         </define-flag>
         <define-flag name="href" as-type="uri-reference" required="yes">
             <formal-name>Catalog or Profile Reference</formal-name>

--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -215,7 +215,7 @@
             <formal-name>Resource Type</formal-name>
             <description>The semantic type of the resource.</description>
             <constraint>
-                <allowed-values allow-others="yes">
+                <allowed-values allow-other="yes">
                     <enum value="catalog">The mapped resource is a control catalog.</enum>
                     <enum value="profile">The mapped resource is a control profile. A resolved
                         profile is also accepted.</enum>


### PR DESCRIPTION
The "source-resource" and "target-resource" assemblies point to a resource URI that control IDs are resolved against. In the current model, they are required to point to an OSCAL Catalog or an OSCAL Profile.

There are two use cases for allowing these URIs to point at non-OSCAL resources: 

1. Mapping between an OSCAL Catalog/Profile and a non-OSCAL resource
    - For example: transitioning from OSCAL to non-OSCAL representations, or translating between OSCAL and non-OSCAL information sources. This serves a real-world purpose that enhances the applicability of OSCAL.

2. Mapping between two non-OSCAL resources
   - This use case decouples the Mapping Model from the wider OSCAL ecosystem and uses it in an independent fashion to accomplish a more generic mapping between resources. Support for this use case is included with no other changes by supporting the above.

As long as the referenced non-OSCAL resource still conceptually contain a list of controls or statements each uniquely identified by an ID, the information model of the mapping holds. The owner of the namespace is still required to communicate processing instructions for the resource types they define if they want processing to function externally.

This Pull Request adds an optional "ns" flag to the "mapping-resource" assembly that qualifies the "type", and also allows non-defined values in "type". When "ns" is not present it is assumed to be the default OSCAL ns, meaning that in cases where a ns field is not included there is no change in behavior.