### PR TITLE
Add provenance overrides to mapping

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -434,8 +434,7 @@
         <description>If automation is used, this can record a confidence score, if assigned.</description>
     </define-field>
 
-    <define-field name="mapping-description" as-type="markup-multiline" min-occurs="0" max-occurs="1"
-        in-xml="WITH_WRAPPER">
+    <define-field name="mapping-description" as-type="markup-multiline">
         <formal-name>Mapping Description</formal-name>
         <description>Description of the context and intended use of the mapping set.</description>
         <remarks> <p>The value of this field applies to the entire document if found in the top-level 

--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -37,6 +37,9 @@
                 per-subject</a>, which means it should be consistently used to identify the same
                 mapping across revisions of the document.</description>
         </define-flag>
+        <flag ref="method" required="no" />
+        <flag ref="matching-rationale" required="no" />
+        <flag ref="status" required="no" />
         <model>
             <assembly ref="mapping-resource-reference" min-occurs="1">
                 <use-name>source-resource</use-name>
@@ -47,6 +50,7 @@
             <assembly ref="map" min-occurs="1" max-occurs="unbounded">
                 <group-as name="maps" in-json="ARRAY" />
             </assembly>
+            <field ref="mapping-description" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
         </model>
     </define-assembly>
 
@@ -330,14 +334,10 @@
         <flag ref="status" required="yes" />
         <model>
             <field ref="confidence-score" min-occurs="1" />
-            <define-field name="mapping-description" as-type="markup-multiline" min-occurs="1"
-                in-xml="WITH_WRAPPER">
-                <formal-name>Mapping Description</formal-name>
-                <description>Description of the context and intended use of the mapping set.</description>
-            </define-field>
             <assembly ref="responsible-party" max-occurs="unbounded">
                 <group-as name="responsible-parties" in-json="ARRAY" />
             </assembly>
+            <field ref="mapping-description" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
             <field ref="remarks" in-xml="WITH_WRAPPER" />
         </model>
     </define-assembly>
@@ -434,6 +434,15 @@
         <description>If automation is used, this can record a confidence score, if assigned.</description>
     </define-field>
 
+    <define-field name="mapping-description" as-type="markup-multiline" min-occurs="0" max-occurs="1"
+        in-xml="WITH_WRAPPER">
+        <formal-name>Mapping Description</formal-name>
+        <description>Description of the context and intended use of the mapping set.</description>
+        <remarks> <p>The value of this field applies to the entire document if found in the top-level 
+        mapping provenance, otherwise it applies to the specific mapping in which it is found.</p>
+        <p>If this field appears in both locations, the lower-scoped value overrides while within it's scope.</p> </remarks>
+    </define-field>
+
     <!-- ################ -->
     <!-- FLAG DEFINITIONS -->
     <!-- ################ -->
@@ -454,11 +463,14 @@
                     two concepts are implemented, performed, or otherwise executed.</enum>
             </allowed-values>
         </constraint>
+        <remarks> <p>The value of this flag applies to the entire document if found in the top-level 
+        mapping provenance, otherwise it applies to the specific mapping in which it is found.</p>
+        <p>If this flag appears in both locations, the lower-scoped value overrides while within it's scope.</p> </remarks>
     </define-flag>
 
     <define-flag name="status" as-type="string">
         <formal-name>Status</formal-name>
-        <description>The focus of the qualifier.</description>
+        <description>The current status of this mapping document.</description>
         <constraint>
             <allowed-values>
                 <enum value="complete">Complete</enum>
@@ -468,6 +480,9 @@
                 <enum value="superseded">Superseded</enum>
             </allowed-values>
         </constraint>
+        <remarks> <p>The value of this flag applies to the entire document if found in the top-level 
+        mapping provenance, otherwise it applies to the specific mapping in which it is found.</p>
+        <p>If this flag appears in both locations, the lower-scoped value overrides while within it's scope.</p> </remarks>
     </define-flag>
 
     <define-flag name="method" as-type="string">
@@ -479,6 +494,9 @@
                 <enum value="automation">Automation</enum>
             </allowed-values>
         </constraint>
+        <remarks> <p>The value of this flag applies to the entire document if found in the top-level 
+        mapping provenance, otherwise it applies to the specific mapping in which it is found.</p>
+        <p>If this flag appears in both locations, the lower-scoped value overrides while within it's scope.</p> </remarks>
     </define-flag>
 
     <!-- TBD: Move assembly to a common file since it is also defined in oscal_profile_metaschema.xml -->


### PR DESCRIPTION
Due to the evolution of the organization of the mapping collection, the information stored in the provenance used to be able to be applied to the entire mapping collection. As a collection can now include multiple separate mappings, the document-level information in provenance needs to be overridable per individual mapping.

This pull request adds the provenance fields and flags to mapping (by reference) and updates documentation to explain the override behavior.