### PR TITLE
Added props, links, and remarks to "provenance" and "mapping"

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -47,6 +47,13 @@
             <assembly ref="map" min-occurs="1" max-occurs="unbounded">
                 <group-as name="maps" in-json="ARRAY" />
             </assembly>
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY" />
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY" />
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
         </model>
     </define-assembly>
 
@@ -338,7 +345,13 @@
             <assembly ref="responsible-party" max-occurs="unbounded">
                 <group-as name="responsible-parties" in-json="ARRAY" />
             </assembly>
-            <field ref="remarks" in-xml="WITH_WRAPPER" />
+            <assembly ref="property" max-occurs="unbounded">
+                <group-as name="props" in-json="ARRAY" />
+            </assembly>
+            <assembly ref="link" max-occurs="unbounded">
+                <group-as name="links" in-json="ARRAY" />
+            </assembly>
+            <field ref="remarks" in-xml="WITH_WRAPPER" min-occurs="0" max-occurs="1" />
         </model>
     </define-assembly>
 


### PR DESCRIPTION
This Pull Request brings the "provenance" and "mapping" assemblies into alignment with typical OSCAL assemblies by adding optional properties, links, and remarks to their model, enabling more implementation flexibility.
