### PR TITLE
Adds confidence-score and coverage as optional at each scope level (document, mapping, map)

### DIFF
--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -47,6 +47,8 @@
             <assembly ref="map" min-occurs="1" max-occurs="unbounded">
                 <group-as name="maps" in-json="ARRAY" />
             </assembly>
+            <field ref="confidence-score" min-occurs="0" max-occurs="1" />
+            <flag ref="coverage" min-occurs="0" max-occurs="1" />
         </model>
     </define-assembly>
 
@@ -158,6 +160,8 @@
                 <use-name>qualifier</use-name>
                 <group-as name="qualifiers" in-json="ARRAY" />
             </assembly>
+            <field ref="confidence-score" min-occurs="0" max-occurs="1" />
+            <flag ref="coverage" min-occurs="0" max-occurs="1" />
             <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY" />
             </assembly>
@@ -329,7 +333,8 @@
         <flag ref="matching-rationale" required="yes" />
         <flag ref="status" required="yes" />
         <model>
-            <field ref="confidence-score" min-occurs="1" />
+            <field ref="confidence-score" min-occurs="0" max-occurs="1" />
+            <flag ref="coverage" min-occurs="0" max-occurs="1" />
             <define-field name="mapping-description" as-type="markup-multiline" min-occurs="1"
                 in-xml="WITH_WRAPPER">
                 <formal-name>Mapping Description</formal-name>
@@ -429,9 +434,41 @@
     <!-- ################# -->
     <!-- FIELD DEFINITIONS -->
     <!-- ################# -->
-    <define-field name="confidence-score" as-type="string">
+    <define-field name="confidence-score">
         <formal-name>Confidence Score</formal-name>
-        <description>If automation is used, this can record a confidence score, if assigned.</description>
+        <description>This records either a string category or a decimal value from 0-1 representing a percentage. Both of these values describe an estimation of the author's confidence
+        that this mapping is correct and accurate. </description>
+        <define-flag name="category" as-type="string" required="no">
+            <constraint>
+                <allowed-values allow-others="yes">
+                    <enum value="unspecified">No category is specified for the confidence score.</enum>
+                    <enum value="high">High confidence in the mapping.</enum>
+                    <enum value="medium">Medium confidence in the mapping.</enum>
+                    <enum value="low">Low confidence in the mapping.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <define-flag name="percentage" as-type="decimal" required="no"/>
+    </define-field>
+
+    <define-field name="coverage" as-type="decimal">
+        <define-flag name="generation-method" as-type="string" required="no" default="arbitrary">
+            <constraint>
+                <allowed-values allow-others="yes">
+                    <enum value="arbitrary">The coverage value is a qualitative estimate of coverage with no strict formula.</enum>
+                </allowed-values>
+            </constraint>
+        </define-flag>
+        <formal-name>Coverage</formal-name>
+        <description>A decimal value from 0-1, representing the percentage coverage of the targets by the sources.</description>
+        <remarks>
+            <p>This field is scoped - that is, it can be used at the document-level, the mapping level, or the individual map item level. It only applies to targets and sources within it's scope.</p>
+            <p>Coverage is calculated by taking the full set of all targets in-scope and the full set of all sources in-scope, then applying the "generation-method" to the two sets.
+             By default the method is an arbitrary estimation of coverage.</p>
+            <p>In a general sense "coverage" is defined as the percent of the set of targets that have mapped to by the set of sources, 
+            where each map is an "equivalent-to" or "equal-to" valued "relationship". Where relationship is "subset-of" or otherwise, it counts as an appropiate fraction of a full map. </p>
+            <p> Since coverage is derived from mapping relationships, it is defined in the context of the mapping's "matching-rationale" - that is, the method used to determine relationships.</p>
+        </remarks>
     </define-field>
 
     <!-- ################ -->

--- a/src/metaschema/oscal_mapping-common_metaschema.xml
+++ b/src/metaschema/oscal_mapping-common_metaschema.xml
@@ -334,7 +334,7 @@
         <flag ref="status" required="yes" />
         <model>
             <field ref="confidence-score" min-occurs="0" max-occurs="1" />
-            <flag ref="coverage" min-occurs="0" max-occurs="1" />
+            <field ref="coverage" min-occurs="0" max-occurs="1" />
             <define-field name="mapping-description" as-type="markup-multiline" min-occurs="1"
                 in-xml="WITH_WRAPPER">
                 <formal-name>Mapping Description</formal-name>
@@ -440,7 +440,7 @@
         that this mapping is correct and accurate. </description>
         <define-flag name="category" as-type="string" required="no">
             <constraint>
-                <allowed-values allow-others="yes">
+                <allowed-values allow-other="yes">
                     <enum value="unspecified">No category is specified for the confidence score.</enum>
                     <enum value="high">High confidence in the mapping.</enum>
                     <enum value="medium">Medium confidence in the mapping.</enum>
@@ -454,7 +454,7 @@
     <define-field name="coverage" as-type="decimal">
         <define-flag name="generation-method" as-type="string" required="no" default="arbitrary">
             <constraint>
-                <allowed-values allow-others="yes">
+                <allowed-values allow-other="yes">
                     <enum value="arbitrary">The coverage value is a qualitative estimate of coverage with no strict formula.</enum>
                 </allowed-values>
             </constraint>
@@ -466,7 +466,7 @@
             <p>Coverage is calculated by taking the full set of all targets in-scope and the full set of all sources in-scope, then applying the "generation-method" to the two sets.
              By default the method is an arbitrary estimation of coverage.</p>
             <p>In a general sense "coverage" is defined as the percent of the set of targets that have mapped to by the set of sources, 
-            where each map is an "equivalent-to" or "equal-to" valued "relationship". Where relationship is "subset-of" or otherwise, it counts as an appropiate fraction of a full map. </p>
+            where each map is an "equivalent-to" or "equal-to" valued "relationship". Where relationship is "subset-of" or otherwise, it counts as an appropriate fraction of a full map. </p>
             <p> Since coverage is derived from mapping relationships, it is defined in the context of the mapping's "matching-rationale" - that is, the method used to determine relationships.</p>
         </remarks>
     </define-field>


### PR DESCRIPTION
This pull request adds confidence-score and coverage as optional at each scope level (document, mapping, map).

"confidence-score" is a field that can hold either a string category ("high","medium","low") or a decimal percentage value between 0 and 1. It represents an estimation of the author's confidence that the mapping within its scope is accurate. Primarily intended to support automation use cases.

"coverage" is a field that captures a percentage value (decimal between 0 and 1) representing the percent that the in-scope sources cover the in-scope targets. By "cover", we mean "satisfy" or "meet", in the context of controls. The exact mechanism for determining this value is declared in the optional and extended "generation-method" flag, which is by default "arbitrary", indicating that no reproducible method was used to generate the coverage value, and it should only be interpreted as an estimate.